### PR TITLE
Add support for xlsx read and csv write

### DIFF
--- a/fsql/api.py
+++ b/fsql/api.py
@@ -116,8 +116,8 @@ def write_object(
     * for Data Frames converts to the specified format (only parquet+fastparquet for now), and then it is written
       using the file-like object from fsspec and dataframe's native write.
 
-    At the moment, only parquet as a format is supported. The only format options are 'engine' with values
-    'fastparquet' and 'pyarrow'.
+    At the moment, only parquet and csv as a format are supported. The only format options are 'engine' with values
+    'fastparquet' and 'pyarrow' (these refer only to parquet format).
 
     For larger data frames or table-like semantics, use rather endpoint (TODO).
 
@@ -139,6 +139,9 @@ def write_object(
                     data.to_parquet(fd, engine=engine)
             else:
                 raise ValueError(f"unsupported engine for dataframe writing: {engine}")
+        elif format == "csv":
+            with fs.open(url_suff, "wb") as fd:
+                data.to_csv(fd)
         else:
             raise ValueError(f"unsupported format for dataframe writing: {format}")
     elif isinstance(data, io.StringIO) or isinstance(data, io.BytesIO):

--- a/fsql/deser.py
+++ b/fsql/deser.py
@@ -48,10 +48,16 @@ class InputFormat(Enum):
     PARQUET = auto()
     JSON = auto()
     CSV = auto()
+    XLSX = auto()
 
     @classmethod
     def from_url(cls, url: str):
-        return {"json": InputFormat.JSON, "parquet": InputFormat.PARQUET, "csv": InputFormat.CSV}[url]
+        return {
+            "json": InputFormat.JSON,
+            "parquet": InputFormat.PARQUET,
+            "csv": InputFormat.CSV,
+            "xlsx": InputFormat.XLSX,
+        }[url]
 
 
 class DataReader(ABC):
@@ -91,6 +97,8 @@ class PandasReader(DataReader):
             reader = lambda fd: pd.read_json(fd, lines=True)  # noqa: E731
         elif input_format is InputFormat.CSV:
             reader = pd.read_csv
+        elif input_format is InputFormat.XLSX:
+            reader = lambda fd: pd.read_excel(fd, engine="openpyxl")  # noqa: E731
         elif input_format is InputFormat.AUTO:
             raise ValueError(f"partition had format detected as auto -> invalid state. Partition: {partition}")
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,6 @@ s3 =
     s3fs <= 0.4.2
     fsspec[s3] <= 2022.2.0
     aiobotocore <= 1.4.2
+
+xlsx =
+    openpyxl


### PR DESCRIPTION
- add support for reading `.xlsx` files
- add support for writing `pd.DataFrame` to `.csv`
- add a test for S3 `.csv` write
- edit a test with local `.csv` write