### PR TITLE
Add generics and lazy error eval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'
+    rev: 'v0.961'
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports, --install-types, --non-interactive]

--- a/fsql/api.py
+++ b/fsql/api.py
@@ -41,14 +41,14 @@ import io
 import logging
 import shutil
 import warnings
-from typing import Iterable, Optional, Tuple, Union
+from typing import Optional, Union
 
 import pandas as pd
 from fsspec.spec import AbstractFileSystem
 
 from fsql import get_url_and_fs
 from fsql.column_parser import AUTO_PARSER, ColumnParser
-from fsql.deser import PANDAS_READER, DataObject, DataReader, PartitionReadFailure
+from fsql.deser import PANDAS_READER, DataObject, DataObjectRich, DataReader
 from fsql.partition import Partition
 from fsql.partition_discovery import discover_partitions
 from fsql.query import Query
@@ -71,9 +71,9 @@ def read_partitioned_table(
     url: str,
     query: Query,
     column_parser: ColumnParser = AUTO_PARSER,
-    data_reader: DataReader[DataObject] = PANDAS_READER,
+    data_reader: DataReader[DataObject] = PANDAS_READER,  # type: ignore
     fs: Optional[AbstractFileSystem] = None,
-) -> Union[DataObject, Tuple[DataObject, Iterable[PartitionReadFailure]]]:
+) -> Union[DataObject, DataObjectRich]:
     """Reads a table rooted at `url`, with partition columns described in `column_parser` and filtered via `query`.
 
     The default values assume `colName1=val/colName2=val` format of the path, and pandas data frame as output format.

--- a/fsql/deser.py
+++ b/fsql/deser.py
@@ -17,6 +17,9 @@ this approach is undesirable due to too-large intermediate representation -- in 
 opt for the lazy approach (such as in Dask), and don't materialize inside neither the `read_single` nor
 `concat` methods.
 
+For custom data readers, mind observing the `lazy_errors` variable -- if it is set, the method `read_single`
+should not raise upon Partition-specific problems, but accumulate the error instead.
+
 Existing readers such as PandasReader allow customisation via passing through any kwargs to the underlying
 pandas read method.
 
@@ -27,13 +30,13 @@ from __future__ import annotations
 
 import json
 import logging
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum, auto, unique
-from functools import partial
-from typing import Any
+from functools import partial, reduce
+from itertools import chain
+from typing import Callable, Generic, Iterable, NamedTuple, Tuple, TypeVar, Union
 
 import pandas as pd
 from fsspec.spec import AbstractFileSystem
@@ -42,6 +45,16 @@ from fsql import assert_exhaustive_enum
 from fsql.partition import Partition
 
 logger = logging.getLogger(__name__)
+
+A = TypeVar("A")
+B = TypeVar("B")
+BiIterator = Tuple[Iterable[A], Iterable[B]]
+
+
+# lambda acc, e: (chain(acc[0], e[0]), chain(acc[1], e[1])) # not sufficient for mypy
+def flatten_biiterator(acc: BiIterator, elem: BiIterator) -> BiIterator:
+    """When used with `reduce`, converts an iterable of tuple(iterable, iterable) to a tuple(iterable, iterable)"""
+    return (chain(acc[0], elem[0]), chain(acc[1], elem[1]))
 
 
 @unique
@@ -64,9 +77,25 @@ class InputFormat(Enum):
         }[url]
 
 
-class DataReader(ABC):
-    def __init__(self, input_format: InputFormat = InputFormat.AUTO):
+DataObject = TypeVar("DataObject")
+
+
+class PartitionReadFailure(NamedTuple):
+    partition: Partition
+    reason: str  # or Any?
+
+
+# NOTE a namedtuple is preferable, but somehow cannot be cast to BiIterator[A, B]...
+# class PartitionReadOutcome(NamedTuple, Generic[DataObject]):
+#     data: Iterable[DataObject]
+#     failures: Iterable[PartitionReadFailure]
+PartitionReadOutcome = Tuple[Iterable[DataObject], Iterable[PartitionReadFailure]]
+
+
+class DataReader(Generic[DataObject]):
+    def __init__(self, input_format: InputFormat = InputFormat.AUTO, lazy_errors=False):
         self.input_format = input_format
+        self.lazy_errors = lazy_errors
 
     def detect_format(self, url: str) -> InputFormat:
         if self.input_format != InputFormat.AUTO:
@@ -75,28 +104,37 @@ class DataReader(ABC):
             return InputFormat.from_url(url.split(".")[-1])
 
     @abstractmethod
-    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> Any:  # TODO generics on the Any
+    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> PartitionReadOutcome:
         raise NotImplementedError("abc")
 
     @abstractmethod
-    def concat(self, data: Iterable[Any]) -> Any:  # TODO generics on the Any
+    def concat(self, outcomes: Iterable[DataObject]) -> DataObject:
         raise NotImplementedError("abc")
 
     def read_and_concat(
         self, partitions: Iterable[Partition], fs: AbstractFileSystem
-    ) -> Any:  # TODO generics on the Any
-        with ThreadPoolExecutor(max_workers=32) as tpe:  # TODO configurable
-            data = tpe.map(partial(self.read_single, fs=fs), partitions)
-        return self.concat(data)
+    ) -> Union[DataObject, Tuple[DataObject, Iterable[PartitionReadFailure]]]:
+        # TODO it is profoundly unfortunate that the return type is Union. Ideally, it would be a generic
+        # type T that is bound with this union, and determined via lazy_error parameter which would be
+        # not a boolean but instead a function [DataObject, T[DataObject]]. Alas, I was not able to pythonize
+        # that. Note this would then apply to the api's signature as well
+        with ThreadPoolExecutor(max_workers=32) as tpe:  # TODO configurable worker count
+            partition_read_outcomes = tpe.map(partial(self.read_single, fs=fs), partitions)
+            if self.lazy_errors:
+                data_objects, failures = reduce(flatten_biiterator, partition_read_outcomes)
+                return (self.concat(data_objects), failures)
+            else:
+                data_objects = chain(*(e[0] for e in partition_read_outcomes))
+                return self.concat(data_objects)
 
 
-class PandasReader(DataReader):
+class PandasReader(DataReader[pd.DataFrame]):
     """Wraps various pandas read methods (parquet, json, csv, excel) into a single interface.
     Behaviour can be customised via passing any kwargs to the constructor.
     """
 
-    def __init__(self, input_format=InputFormat.AUTO, **pdread_kwargs):
-        super().__init__(input_format=input_format)
+    def __init__(self, input_format=InputFormat.AUTO, lazy_errors=False, **pdread_kwargs):
+        super().__init__(input_format=input_format, lazy_errors=lazy_errors)
         self.pdread_user_kwargs = pdread_kwargs
         self.pdread_default_kwargs = defaultdict(dict)
         self.pdread_default_kwargs[InputFormat.PARQUET] = {
@@ -109,65 +147,85 @@ class PandasReader(DataReader):
             "engine": "openpyxl",
         }
 
-    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> pd.DataFrame:
-        logger.debug(f"read dataframe for partition {partition}")
-        input_format = self.detect_format(partition.url)
-        logger.debug(f"format detected for partition {input_format} <- {partition}")
+    def format_to_reader(self, input_format: InputFormat) -> Callable:
         if input_format is InputFormat.PARQUET:
-            reader = pd.read_parquet
+            return pd.read_parquet
         elif input_format is InputFormat.JSON:
-            reader = pd.read_json
+            return pd.read_json
         elif input_format is InputFormat.CSV:
-            reader = pd.read_csv
+            return pd.read_csv
         elif input_format is InputFormat.XLSX:
-            reader = pd.read_excel
+            return pd.read_excel
         elif input_format is InputFormat.AUTO:
-            raise ValueError(f"partition had format detected as auto -> invalid state. Partition: {partition}")
+            raise ValueError("partition had format detected as auto -> invalid state.")
         else:
             assert_exhaustive_enum(input_format)
 
+    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> PartitionReadOutcome:
+        logger.debug(f"read dataframe for partition {partition}")
+        input_format = self.detect_format(partition.url)
+        logger.debug(f"format detected for partition {input_format} <- {partition}")
+        reader = self.format_to_reader(input_format)
+
         pdread_kwargs = {**self.pdread_default_kwargs[input_format], **self.pdread_user_kwargs}
         logger.debug(f"reader kwargs {pdread_kwargs} for partition {partition}")
-        try:
+
+        def read_dataframe(partition: Partition) -> PartitionReadOutcome:
             with fs.open(partition.url, "rb") as fd:
-                df = reader(fd, **pdread_kwargs)
+                try:
+                    df = reader(fd, **pdread_kwargs)
+                    for key, value in partition.columns.items():
+                        df[key] = value
+                    return ([df], [])
+                except ValueError as e:
+                    if not self.lazy_errors:
+                        raise
+                    else:
+                        return ([], [PartitionReadFailure(partition, str(e))])
+
+        try:
+            result = read_dataframe(partition)
         except FileNotFoundError as e:
             logger.warning(f"file {partition} reading exception {type(e)}, attempting cache invalidation and reread")
             fs.invalidate_cache()
-            with fs.open(partition.url, "rb") as fd:
-                df = reader(fd, **pdread_kwargs)
+            result = read_dataframe(partition)
 
-        for key, value in partition.columns.items():
-            df[key] = value
-        return df
+        return result
 
-    def concat(self, data: Iterable[Any]) -> Any:  # TODO generics on the Any
+    def concat(self, data: Iterable[pd.DataFrame]) -> pd.DataFrame:
         return pd.concat(data)
 
 
 PANDAS_READER = PandasReader()
 
 
-class EnumeratedDictReader(DataReader):
-    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> dict:
+class EnumeratedDictReader(DataReader[dict]):
+    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> PartitionReadOutcome:
         logger.debug(f"read single for partition {partition}")
         input_format = self.detect_format(partition.url)
         if input_format != InputFormat.JSON:
             raise ValueError(f"EnumeratedDictReader supports only json, not {input_format}. Partition is {partition}")
 
-        def read_json(url):
-            with fs.open(url, "r") as fd:
-                return json.load(fd)
+        def read_dict(partition: Partition) -> PartitionReadOutcome:
+            with fs.open(partition.url, "r") as fd:
+                try:
+                    base = json.load(fd)
+                    return ([{**base, **partition.columns}], [])
+                except json.decoder.JSONDecodeError as e:
+                    if not self.lazy_errors:
+                        raise
+                    else:
+                        return ([], [PartitionReadFailure(partition, str(e))])
 
         try:
-            base = read_json(partition.url)
+            result = read_dict(partition)
         except FileNotFoundError as e:
             logger.warning(f"file {partition} reading exception {type(e)}, attempting cache invalidation and reread")
             fs.invalidate_cache()
-            base = read_json(partition.url)
-        return {**base, **partition.columns}
+            result = read_dict(partition)
+        return result
 
-    def concat(self, data: Iterable[Any]) -> Any:  # TODO generics on the Any
+    def concat(self, data: Iterable[dict]) -> dict:
         return dict(enumerate(data))
 
 

--- a/tests/test_dict_reader.py
+++ b/tests/test_dict_reader.py
@@ -1,7 +1,10 @@
 import json
+import re
+
+import pytest
 
 from fsql.api import read_partitioned_table
-from fsql.deser import ENUMERATED_DICT_READER
+from fsql.deser import ENUMERATED_DICT_READER, EnumeratedDictReader
 from fsql.query import Q_TRUE
 
 
@@ -18,3 +21,23 @@ def test_dict_reader(helper):
     data = read_partitioned_table(f"s3://{bucket}/", Q_TRUE, data_reader=ENUMERATED_DICT_READER)
 
     assert data == {0: element1, 1: element2}
+
+
+def test_lazy_errors(tmp_path):
+    case1_path = tmp_path / "table1"
+    case1_path.mkdir(parents=True)
+    data1 = """{"c1": 4}"""
+    data2 = """whopsie dupsie parsing oopsie"""
+    with open(case1_path / "f1.json", "w") as fd:
+        fd.write(data1)
+    with open(case1_path / "f2.json", "w") as fd:
+        fd.write(data2)
+
+    error_line = "Expecting value: line 1 column 1 (char 0)"
+    with pytest.raises(json.decoder.JSONDecodeError, match=re.escape(error_line)):
+        read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=ENUMERATED_DICT_READER)
+
+    lazy_reader = EnumeratedDictReader(lazy_errors=True)
+    result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=lazy_reader)
+    assert result[0] == {0: json.loads(data1)}
+    assert [error_line] == [e.reason for e in result[1]]

--- a/tests/test_pandasreader.py
+++ b/tests/test_pandasreader.py
@@ -7,6 +7,7 @@ from fsql.deser import InputFormat, PandasReader
 from fsql.query import Q_TRUE
 
 df1 = pd.DataFrame(data={"c1": [0, 1], "c2": ["hello", "world"]})
+df2 = pd.DataFrame(data={"c1": [2, 3], "c2": ["hello", "world"], "c3": [0.1, 0.2]})
 
 
 def test_input_format_override(tmp_path):
@@ -18,7 +19,7 @@ def test_input_format_override(tmp_path):
 
     with pytest.raises(ValueError, match="Expected object or value"):
         # this test condition is quite brittle! A better match would be desired
-        failure_result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE)
+        read_partitioned_table(f"file://{case1_path}/", Q_TRUE)
 
     reader = PandasReader(input_format=InputFormat.CSV)
     succ_result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=reader)
@@ -35,3 +36,21 @@ def test_parquet_kwargs(tmp_path):
     reader = PandasReader(columns=["c2"])
     result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=reader)
     assert_frame_equal(df1[["c2"]], result)
+
+
+def test_lazy_errors(tmp_path):
+    """Create two parquets with different schema and test that only one is correctly read."""
+    case1_path = tmp_path / "table1"
+    case1_path.mkdir(parents=True)
+    df1.to_parquet(case1_path / "f1.parquet", index=False)
+    df2.to_parquet(case1_path / "f2.parquet", index=False)
+
+    error_line = "Following columns were requested but are not available: {'c3'}."
+    with pytest.raises(ValueError, match=error_line):
+        reader_eager = PandasReader(columns=["c3"])
+        result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=reader_eager)
+    reader_lazy = PandasReader(columns=["c3"], lazy_errors=True)
+    result = read_partitioned_table(f"file://{case1_path}/", Q_TRUE, data_reader=reader_lazy)
+    assert_frame_equal(df2[["c3"]], result[0])
+    reasons = [e.reason.split("\n")[0] for e in result[1]]
+    assert reasons == [error_line]


### PR DESCRIPTION
1. Adds generics to DataReader and api.py. It is an improvement, yet it is far from ideal. I failed to do more, with my current understanding of python and mypy
2. Adds the functionality for accumulating error descriptions instead of raising -- and tests covering this functionality
3. A minor changes to PandasReader -- the format->pd.read function part is moved to its own function; and the FileNotFound handling had reduced code duplication (now it works as in the EnumeratedDict reader)

to the reviewer -- I suggest you check out the tests first, then you look at the EnumeratedDict reader where the change is probably a little easier to comprehend. Then check out the changes to the abstract DataReader class -- the part with biiterator flattening may be a bit weird so be careful. Conclude with the PandasReader