### PR TITLE
Add dask support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,19 @@
-name: publish
-on: [release]
-jobs:
-  build-package:
-    runs-on: ubuntu-latest
-    steps:
-     - uses: actions/checkout@v3
-     - uses: actions/setup-python@v2
-       with:
-         python-version: 3.8.8
-     - run: make build
-     - uses: actions/upload-archive@v2
-       with:
-         name: package-distribution
-         path: dist
-     - uses: pypa/gh-action-pypi-publish@release/v1 # https://github.com/pypa/gh-action-pypi-publish
-       with:
-         user: "fsql-ampx"
-         password: ${{ secrets.PYPIPASSWORD }}
-
+# name: publish
+# on: [release]
+# jobs:
+#   build-package:
+#     runs-on: ubuntu-latest
+#     steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.8.8
+#      - run: make build
+#      - uses: actions/upload-archive@v2
+#        with:
+#          name: package-distribution
+#          path: dist
+#      - uses: pypa/gh-action-pypi-publish@release/v1 # https://github.com/pypa/gh-action-pypi-publish
+#        with:
+#          user: "fsql-ampx"
+#          password: ${{ secrets.PYPIPASSWORD }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,4 +26,20 @@ jobs:
      - uses: rymndhng/release-on-push-action@v0.25.0 # https://github.com/marketplace/actions/tag-release-on-push-action
        with:
          bump_version_scheme: minor
-
+  publish:
+    tags: 'v*'
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v3
+     - uses: actions/setup-python@v2
+       with:
+         python-version: 3.8.8
+     - run: make build
+     - uses: actions/upload-archive@v2
+       with:
+         name: package-distribution
+         path: dist
+     - uses: pypa/gh-action-pypi-publish@release/v1 # https://github.com/pypa/gh-action-pypi-publish
+       with:
+         user: "__token__"
+         password: ${{ secrets.PYPITOKEN }}

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,5 @@
 multi_line_output = 3
 include_trailing_comma = true
 line_length = 120
-known_third_party = fsspec,moto,pandas,pytest,setuptools
+known_third_party = dask,fsspec,moto,pandas,pytest,setuptools
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The core is installed just via `pip install fsql`. Additional filesystem support
 
 For examples of usage, we use selected test files accompanied with explanatory comments:
 1. [basic usage](tests/test_example_usage.py),
-2. [date range utils](tests/test_daterange.py).
+2. [date range utils](tests/test_daterange.py),
+3. [integrating with Dask](tests/test_dask.py).
 
 ## Use Cases & Features
 The canonical usecase is that you have data on `S3` stored e.g. as `<table_name>/year=<yyyy>/month=<mm>/day=<dd>/<filename>.csv`, and you want to fetch a part of it (e.g., a week from the last month, every Monday last year, ...) as a single Pandas or Dask DataFrame, via a short command -- without having to write the `boto3` crawl, the bytes2csv, the csv2pandas, etc.

--- a/fsql/deser_dask.py
+++ b/fsql/deser_dask.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import itertools
+import logging
+from collections.abc import Iterable
+from typing import Any, Iterator
+
+import dask
+import dask.dataframe as dd
+from fsspec.spec import AbstractFileSystem
+
+from fsql.deser import DataReader, PandasReader, PartitionReadFailure, PartitionReadOutcome
+from fsql.partition import Partition
+
+logger = logging.getLogger(__name__)
+
+
+class DaskReader(DataReader):
+    """Works by reading every single partition via PandasReader in a delayed task, concatenating together,
+    and returning the resulting Dask DataFrame.
+
+    There is one inconvenience -- in order to create the Dask DataFrame, we need the `meta` (ie, the schema).
+    If the user does not provide it, we *compute* the first partition here, derive `meta` from it, and proceed
+    by turning the remaining Delayed tasks into the Dask DataFrame.
+    """
+
+    def __init__(self, meta=None, pandas_reader=None, lazy_errors=False):
+        super().__init__(lazy_errors=lazy_errors)
+        if pandas_reader and pandas_reader.lazy_errors:
+            logger.warning("provided pandas reader has lazy_errors=True, which makes no sense as it is delayed")
+        self.pandas_reader = pandas_reader if pandas_reader else PandasReader(lazy_errors=False)
+        self.meta = meta
+
+    def read_single(self, partition: Partition, fs: AbstractFileSystem) -> PartitionReadOutcome:
+        try:
+            # PandasReader returns PartitionReadOutcome, not DataFrame -- so we need to convert accordingly
+            convert = lambda pandas_outcome: pandas_outcome[0][0]  # noqa: E731
+            delayed_reader = lambda partition, fs: convert(self.pandas_reader.read_single(partition, fs))  # noqa: E731
+            return [dask.delayed(delayed_reader)(partition, fs)], []
+        except ValueError as e:
+            if not self.lazy_errors:
+                raise
+            else:
+                return [], [PartitionReadFailure(partition, str(e))]
+
+    def concat(self, data: Iterable[Any]) -> Any:  # TODO generics on the Any... which is tricky as dd aint Delayed!
+        if self.meta:
+            dd_iter: Iterator[Any] = (dd.from_delayed(e, meta=self.meta) for e in data)
+        else:
+            iterator = iter(data)
+            head = next(iterator).compute()
+            tail = (dd.from_delayed(e, meta=head) for e in iterator)
+            head_dd = dd.from_pandas(head, npartitions=1)
+            dd_iter = itertools.chain([head_dd], tail)
+        # looks like a nuissance of dask, they require list instead of any Iterable...
+        return dd.concat(list(dd_iter))

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,15 @@ test =
     pyarrow
     moto
     pytest
-    fsspec[s3] >= 2022.5.0
+    %(s3)s
+    %(xlsx)s
+    %(dask)s
 
 s3 =
     fsspec[s3] >= 2022.5.0
 
 xlsx =
     openpyxl
+
+dask =
+    dask

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -1,0 +1,45 @@
+import logging
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from fsql.api import read_partitioned_table
+from fsql.column_parser import AutoParser
+from fsql.deser_dask import DaskReader
+from fsql.query import Q_TRUE
+
+logging.basicConfig(level=logging.DEBUG, force=True)
+logging.getLogger("botocore").setLevel(level=logging.ERROR)
+
+
+def test_dask(tmp_path):
+    """Here we demonstrate a drop-in replacement of Pandas reader with a Dask reader. The underlying logic
+    of Pandas reader (the default one) is to merge all files into a single dataframe, which may, at times,
+    be unscalable or undesirable. Instead, Dask reader converts every single file into one partition of the
+    Dataframe, in a lazy way. Therefore, `read_partitioned_table` reads just a single file to derive the
+    metadata, and returns to you an object which will initiate the reading once you trigger some `compute`.
+    """
+
+    df1 = pd.DataFrame({"a": [1, 2]})
+    df2 = pd.DataFrame({"a": [3, 4]})
+    df3 = pd.DataFrame({"a": [5, 6]})
+    pr1 = tmp_path / "c1=1"
+    pr2 = tmp_path / "c1=2"
+    pr3 = tmp_path / "c1=3"
+    pr1.mkdir(parents=True)
+    pr2.mkdir(parents=True)
+    pr3.mkdir(parents=True)
+    df1.to_csv(pr1 / "f1.csv", index=False)
+    df2.to_csv(pr2 / "f2.csv", index=False)
+    df3.to_csv(pr3 / "f3.csv", index=False)
+
+    reader = DaskReader()
+    parser = AutoParser.from_str("c1=[1,2]")
+    result = read_partitioned_table(f"file://{tmp_path}/", Q_TRUE, parser, reader).compute()
+    expect = pd.concat([df1.assign(c1="1"), df2.assign(c1="2")])
+    assert_frame_equal(expect, result)
+
+    # There are times when even this behaviour is not a good idea -- the first file may not give correct
+    # information for metadata derivation, you may want to do some other operation on the list of delayed
+    # tasks instead of concatenating to a dataframe right away, etc... In that case, you best subclass
+    # the DaskReader on your own, or just use it as a starting point.

--- a/tests/test_daterange.py
+++ b/tests/test_daterange.py
@@ -48,3 +48,7 @@ def test_daterange_utils(tmp_path):
     result_parser = read_partitioned_table(f"file://{tmp_path}/", Q_TRUE, parser)
 
     assert_frame_equal(result_parser, expect)
+
+    # Note that if you use a long date range, you may end up with a large number of files being merged
+    # into a single dataframe. This is one of situations where using Dask may make sense -- feel free to
+    # head over to test_dask


### PR DESCRIPTION
Compared to the original https://gitlab.com/ampx/aiml/ampx-fsql/-/merge_requests/11/diffs , there are a few changes:
- the `lazy_errors` has been introduced, and that complicated things a bit -- this is the `convert` lambda from the `DaskReader.read_single` etc
- the generics were introduced, but that does not affect with this one (the original comment about the generics being difficult in this particular case still stand)
- the handling of a missing end-`/` has been handled differently, so that part of the code is not required anymore

but the core functionality is intact