### PR TITLE
remove double inheritance with NamedTuple error

### DIFF
--- a/fsql/deser.py
+++ b/fsql/deser.py
@@ -92,7 +92,7 @@ class InputFormat(Enum):
 DataObject = TypeVar("DataObject")
 
 
-class DataObjectRich(NamedTuple, Generic[DataObject]):
+class DataObjectRich(Generic[DataObject]):
     data: DataObject
     failures: Iterable[PartitionReadFailure]
 


### PR DESCRIPTION
remove double inheritance with NamedTuple to avoid TypeError, as per python 3.9: 
https://github.com/python/cpython/pull/19363