### PR TITLE
Run python 3.9 tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
 jobs:
   test-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,13 +6,17 @@ on:
 jobs:
   test-suite:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8.8', '3.9.12' ]
+    name: Python ${{ matrix.python-version }} test
     steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
      - uses: actions/setup-python@v2
        with:
-         python-version: 3.8.8
+         python-version: ${{ matrix.python-version }}
      - run: make static-analysis test-suite
      # - uses: actions/upload-artifact@v3 # todo -- this would use some easily displayable artifact
      #   with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8.8', '3.9.12' ]
+        python-version: [ '3.8.8', '3.9.12' ] # TODO add more later on
     name: Python ${{ matrix.python-version }} test
     steps:
      - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ ipython_config.py
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# you can override this variable when you have eg .venv-py38 and .venv-py39
+VENV_CORE=.venv
+
 clean: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
@@ -15,15 +18,16 @@ clean: ## remove build artifacts
 	rm -rf .cache
 	rm -rf .pytest_cache
 	rm -rf .mypy_cache
-	rm -rf .venv-precommit
-	rm -rf .venv-test
+	rm -rf "${VENV_CORE}-precommit"
+	rm -rf "${VENV_CORE}-test"
+	rm -rf "${VENV_CORE}-build"
 	rm -f index.html
 
 static-analysis: ## run mypy, black, flake, etc
 	(\
 		set -e ; \
-		python -m venv .venv-precommit; \
-		. .venv-precommit/bin/activate; \
+		python -m venv "${VENV_CORE}-precommit"; \
+		. "${VENV_CORE}-precommit/bin/activate"; \
 		pip install -U pip; \
 		pip install pre-commit; \
 		pre-commit install --install-hooks; \
@@ -33,8 +37,8 @@ static-analysis: ## run mypy, black, flake, etc
 test-suite: ## install new venv, run tests and coverage
 	(\
 		set -e ; \
-		python -m venv .venv-test; \
-		. .venv-test/bin/activate; \
+		python -m venv "${VENV_CORE}-test"; \
+		. "${VENV_CORE}-test/bin/activate"; \
 		pip install -U pip; \
 		pip install .[test]; \
 		coverage run --source fsql -m pytest --junit-xml=results.xml tests/; \
@@ -48,8 +52,8 @@ install-edit: clean ## install the package in editable mode
 build: clean
 	(\
 		set -e ; \
-		python -m venv .venv-build; \
-		. .venv-build/bin/activate; \
+		python -m venv "${VENV_CORE}-build"; \
+		. "${VENV_CORE}-build/bin/activate"; \
 		pip install -U pip; \
 		pip install -U build; \
 		if [ "$$GITHUB_REF_TYPE" = "tag" ] ; then export TARGET_VERSION=$$GITHUB_REF_NAME ; \


### PR DESCRIPTION
- Adding a parallel run of a test for py39.
- Nothing around release etc changed -- the wheel should be version-independent (we claim `py>=3.8`, we may want to restrict from above, only for the python versions we test for... latest when we hit some bug in high pythons we cannot fix)
- Added minor convenience to Makefile