### PR TITLE
Raise when unsupported format written

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ ipython_config.py
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/fsql/api.py
+++ b/fsql/api.py
@@ -156,3 +156,5 @@ def write_object(
         mode = "wb" if isinstance(data, io.BytesIO) else "w"
         with fs.open(url_suff, mode) as fd:
             shutil.copyfileobj(data, fd)
+    else:
+        raise ValueError(f"cannot infer writer for object of type {type(data)}")

--- a/tests/test_write_object.py
+++ b/tests/test_write_object.py
@@ -74,3 +74,16 @@ def test_wrong_formats():
     bf = io.StringIO("hello")
     with pytest.raises(ValueError):
         write_object("file://whatever", bf, "parquet")
+
+    just_bytes = b"hello"
+    with pytest.raises(ValueError, match=r"cannot infer writer.*"):
+        write_object("file://whatever", just_bytes)
+
+
+def test_write_vanilla_bytes(tmpdir):
+    path = tmpdir.join("f1")
+    data = b"ahoj"
+    write_object(f"file://{path}", io.BytesIO(data))
+    with open(path, "rb") as f:
+        extracted = f.read()
+    assert extracted == data


### PR DESCRIPTION
When unsupported object was passed to write object, it silently did nothing. We now raise error instead. Tests are improved.