### PR TITLE
Fix cache invalidation in IdentityReader

### DIFF
--- a/fsql/deser.py
+++ b/fsql/deser.py
@@ -277,14 +277,15 @@ class FileInPartition:
     fs: AbstractFileSystem
 
     def consume(self, fd_consumer: Callable[[OpenFile], Any]):
-        with self.fs.open(self.file_url) as fd:
-            try:
+        try:
+            with self.fs.open(self.file_url) as fd:
                 return fd_consumer(fd)
-            except FileNotFoundError as e:
-                logger.warning(
-                    f"file {self.file_url} reading exception {type(e)}, attempting cache invalidation and reread"
-                )
-                self.fs.invalidate_cache()
+        except FileNotFoundError as e:
+            logger.warning(
+                f"file {self.file_url} reading exception {type(e)}, attempting cache invalidation and reread"
+            )
+            self.fs.invalidate_cache()
+            with self.fs.open(self.file_url) as fd:
                 return fd_consumer(fd)
 
 


### PR DESCRIPTION
The try-catch has to be one level higher, the self.open is already throwing the file not found exception

No idea how to unit-test this better, happens only with remote connections...