### PR TITLE
Add write support to json from pd.DataFrame

### DIFF
--- a/src/fsql/api.py
+++ b/src/fsql/api.py
@@ -147,6 +147,9 @@ def write_object(
         elif format == "csv":
             with fs.open(url_suff, "wb") as fd:
                 data.to_csv(fd)
+        elif format == "json":
+            with fs.open(url_suff, "wb") as fd:
+                data.to_json(fd)
         else:
             raise ValueError(f"unsupported format for dataframe writing: {format}")
     elif isinstance(data, io.StringIO) or isinstance(data, io.BytesIO):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Sets a mock/fake of the S3 filesystem for any `fsql`-based usage."""
+import json
 import os
 
 import fsspec
@@ -13,6 +14,10 @@ class Helper:
     def put_s3_file(self, data, url):
         with self.s3fs.open(url, "wb") as fd:
             fd.write(data)
+
+    def read_json_file(self, url):
+        with self.s3fs.open(url, "r") as fd:
+            return json.load(fd)
 
 
 @pytest.fixture


### PR DESCRIPTION
Similarly to https://github.com/AmpX-AI/fsql/pull/5 this PR adds a `write_object` support for `format="json"` from `pd.DataFrame` to json file. Adds tests as well.