### PR TITLE
update python version in actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
          fetch-depth: 0
      - uses: actions/setup-python@v2
        with:
-         python-version: 3.8.8
+         python-version: 3.8.16
      - run: make static-analysis test-suite
      # - uses: actions/upload-artifact@v3 # todo -- this would use some easily displayable artifact
      #   with:
@@ -37,7 +37,7 @@ jobs:
          fetch-depth: 0
      - uses: actions/setup-python@v2
        with:
-         python-version: 3.8.8
+         python-version: 3.8.16
      - run: make build
      - uses: pypa/gh-action-pypi-publish@release/v1 # https://github.com/pypa/gh-action-pypi-publish
        with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8.8', '3.9.12' ] # TODO add more later on
+        python-version: [ '3.8.16', '3.9.12' ] # TODO add more later on
     name: Python ${{ matrix.python-version }} test
     steps:
      - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: seed-isort-config
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.12.0
     hooks:
     - id: isort
 -   repo: https://github.com/ambv/black
@@ -12,8 +12,8 @@ repos:
     hooks:
     - id: black
       language_version: python3.8
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.8
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:


### PR DESCRIPTION
`ubuntu-latest` was updated to now point to `ubuntu-22.04` and as a result testing pipeline now fails with `Error: Version 3.8.8 with arch x64 not found`. See also https://stackoverflow.com/questions/74673048/github-actions-setup-python-stopped-working

- updated python version to `3.8.16`
- update pre-commit file